### PR TITLE
Added 1.8 stone variant recipes to the Fancy Stone Smelter 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2456,6 +2456,9 @@ production_factories:
         amount: 256
         durability: 4
     recipes:
+      - Smelt_Diorite
+      - Smelt_Granite
+      - Smelt_Andesite
       - Smelt_Prismarine
       - Smelt_Prismarine_Bricks
       - Smelt_Dark_Prismarine
@@ -10947,3 +10950,48 @@ production_recipes:
         Emerald Blocks:
           material: EMERALD_BLOCK
           amount: 84
+ Smelt_Diorite:
+    name: Smelt Diorite
+    production_time: 64
+    inputs:
+      Cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      Flint:
+        material: FLINT
+        amount: 64
+    outputs:
+      Diorite:
+        material: STONE
+        amount: 64
+        durability: 3
+ Smelt_Granite:
+    name: Smelt Granite
+    production_time: 64
+    inputs:
+      Cobblestone:
+        material: COBBLESTONE
+        amount: 64
+      Flint:
+        material: FLINT
+        amount: 128
+    outputs:
+      Granite:
+        material: STONE
+        amount: 64
+        durability: 1
+ Smelt_Andesite:
+    name: Smelt Andesite
+    production_time: 64
+    inputs:
+      Cobblestone:
+        material: COBBLESTONE
+        amount: 96
+      Flint:
+        material: FLINT
+        amount: 64
+    outputs:
+      Andesite:
+        material: STONE
+        amount: 64
+        durability: 5


### PR DESCRIPTION
Added Andesite, Diorite, and Granite recipes to the Fancy Stone Smelter that are made with Cobblestone and Flint. I ensured to make the costs of each recipe to reflect the costs in their vanilla equivalent, and made it so that you simply can't get a larger amount of Andesite from vanilla minecraft crafting Cobblestone and Diorite than from using the factory recipe.

Each of these materials spawn commonly in vanilla minecraft, and so it makes sense to add a factory recipe that makes these materials more attainable than through their vanilla quartz recipe, given that these materials with only aesthetic purposes would be quite costly given how ores generate on this map. Gravel spawns throughout the map almost as much as the stone variants in a vanilla 1.8 world, so it seemed fitting to give flint a better use while also not making the recipes as simple as a cobblestone input and granite output.
